### PR TITLE
Fixbug: Import bitly_api python 3.5

### DIFF
--- a/bitly_api/__init__.py
+++ b/bitly_api/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from bitly_api.bitly_api import Connection, BitlyError, Error
+from .bitly_api import Connection, BitlyError, Error
 __version__ = '0.3'
 __author__ = "Jehiah Czebotar <jehiah@gmail.com>"
 __all__ = ["Connection", "BitlyError", "Error"]


### PR DESCRIPTION
Exist the bug of import in Python 3.5 Connection, BitlyError, Error. Path relative